### PR TITLE
Backwards compatibility fix for network < 3.0

### DIFF
--- a/HSNTP/Util/Misc.hs
+++ b/HSNTP/Util/Misc.hs
@@ -5,7 +5,7 @@ import Control.Exception
 import Control.Monad.Error
 import Foreign
 import Foreign.Ptr
-import Network.Socket
+import Network.Socket hiding (sClose)
 import Prelude hiding (catch)
 
 import HSNTP.Util.UDP

--- a/HSNTP/Util/UDP.hs
+++ b/HSNTP/Util/UDP.hs
@@ -21,7 +21,7 @@ module HSNTP.Util.UDP (connectUDP, listenUDP,
                 ) where
 
 import Network.BSD
-import Network.Socket
+import Network.Socket hiding (sClose)
 
 
 #if (__GLASGOW_HASKELL__ < 603)

--- a/HSNTP/Util/UDPClient.hs
+++ b/HSNTP/Util/UDPClient.hs
@@ -6,7 +6,7 @@ import Control.Exception
 import Control.Monad
 import Foreign
 import Foreign.Ptr
-import Network.Socket
+import Network.Socket hiding (sClose)
 import Prelude hiding(catch)
 
 import HSNTP.Util.Misc


### PR DESCRIPTION
network >= 3.0 broke another project that depends on this; downgrading
introduced clashing definitions of 'sClose', which this fixes.